### PR TITLE
chore(deps): bump popper.js from 2.9.3 to1.16.1-lts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>popper.js</artifactId>
-            <version>2.9.3</version>
+            <version>1.16.1-lts</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
chore(deps): bump popper.js from 2.9.3 to1.16.1-lts

Related #2 